### PR TITLE
🐛 r/externalauth_kerberos: deprecate login_attribute argument

### DIFF
--- a/.changes/hotfix_external_auth_kerberos.md
+++ b/.changes/hotfix_external_auth_kerberos.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+BUG FIXES:
+
+* **resource/wallix-bastion_externalauth_kerberos**: deprecate `login_attribute` argument (it produces Bad Request with API v3.12)

--- a/bastion/resource_externalauth_kerberos.go
+++ b/bastion/resource_externalauth_kerberos.go
@@ -21,7 +21,6 @@ type jsonExternalAuthKerberos struct {
 	Host                 string `json:"host"`
 	KerDomController     string `json:"ker_dom_controller"`
 	KeyTab               string `json:"keytab,omitempty"`
-	LoginAttribute       string `json:"login_attribute"`
 	Type                 string `json:"type"`
 }
 
@@ -69,6 +68,8 @@ func resourceExternalAuthKerberos() *schema.Resource {
 			"login_attribute": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Deprecated: "Remove this attribute's configuration as it no longer is used" +
+					" and the attribute will be removed in the next major version of the provider.",
 			},
 			"use_primary_auth_domain": {
 				Type:     schema.TypeBool,
@@ -275,7 +276,6 @@ func prepareExternalAuthKerberosJSON(d *schema.ResourceData) jsonExternalAuthKer
 		Port:                 d.Get("port").(int),
 		Description:          d.Get("description").(string),
 		KeyTab:               d.Get("keytab").(string),
-		LoginAttribute:       d.Get("login_attribute").(string),
 		UsePrimaryAuthDomain: d.Get("use_primary_auth_domain").(bool),
 		Type:                 "KERBEROS",
 	}
@@ -326,9 +326,6 @@ func fillExternalAuthKerberos(d *schema.ResourceData, jsonData jsonExternalAuthK
 		panic(tfErr)
 	}
 	if tfErr := d.Set("description", jsonData.Description); tfErr != nil {
-		panic(tfErr)
-	}
-	if tfErr := d.Set("login_attribute", jsonData.LoginAttribute); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("use_primary_auth_domain", jsonData.UsePrimaryAuthDomain); tfErr != nil {

--- a/bastion/resource_externalauth_kerberos.go
+++ b/bastion/resource_externalauth_kerberos.go
@@ -68,7 +68,7 @@ func resourceExternalAuthKerberos() *schema.Resource {
 			"login_attribute": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Deprecated: "Remove this attribute's configuration as it no longer is used" +
+				Deprecated: "Remove this attribute's configuration as it is not used anymore" +
 					" and the attribute will be removed in the next major version of the provider.",
 			},
 			"use_primary_auth_domain": {

--- a/bastion/resource_externalauth_kerberos_test.go
+++ b/bastion/resource_externalauth_kerberos_test.go
@@ -1,3 +1,4 @@
+// nolint: lll,nolintlint
 package bastion_test
 
 import (
@@ -33,12 +34,17 @@ func TestAccResourceExternalAuthKerberos_basic(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "testacc_ExternalAuthKerberos",
 			},
+			{
+				Config: testAccResourceExternalAuthKerberosCreate2(),
+			},
+			{
+				Config: testAccResourceExternalAuthKerberosUpdate2(),
+			},
 		},
 		PreventPostDestroyRefresh: true,
 	})
 }
 
-// nolint: lll,nolintlint
 func testAccResourceExternalAuthKerberosCreate() string {
 	k, _ := hex.DecodeString(keytabDataHexStr)
 	os.WriteFile("/tmp/testacc_data", k, 0644) //nolint: all
@@ -55,7 +61,6 @@ resource "wallix-bastion_externalauth_kerberos" "testacc_ExternalAuthKerberos" {
 `
 }
 
-// nolint: lll,nolintlint
 func testAccResourceExternalAuthKerberosUpdate() string {
 	return `
 data "wallix-bastion_version" "v" {}
@@ -63,10 +68,38 @@ resource "wallix-bastion_externalauth_kerberos" "testacc_ExternalAuthKerberos" {
   authentication_name     = "testacc_ExternalAuthKerberos"
   host                    = "server1"
   ker_dom_controller      = "EXAMPLE.COM"
-  port                    = 88
-  kerberos_password       = true
+  port                    = 188
   description             = "testacc ExternalAuthKerberos"
-  login_attribute         = "attribute"
+  use_primary_auth_domain = true
+  keytab                  = split(".", data.wallix-bastion_version.v.wab_version)[0] == "8" ? "" : filebase64("/tmp/testacc_data")
+}
+`
+}
+
+func testAccResourceExternalAuthKerberosCreate2() string {
+	return `
+data "wallix-bastion_version" "v" {}
+resource "wallix-bastion_externalauth_kerberos" "testacc_ExternalAuthKerberosPassword" {
+  authentication_name = "testacc_ExternalAuthKerberosPassword"
+  host                = "server2"
+  ker_dom_controller  = "EXAMPLE.COM"
+  kerberos_password   = true
+  port                = 88
+  keytab              = split(".", data.wallix-bastion_version.v.wab_version)[0] == "8" ? "" : filebase64("/tmp/testacc_data")
+}
+`
+}
+
+func testAccResourceExternalAuthKerberosUpdate2() string {
+	return `
+data "wallix-bastion_version" "v" {}
+resource "wallix-bastion_externalauth_kerberos" "testacc_ExternalAuthKerberosPassword" {
+  authentication_name     = "testacc_ExternalAuthKerberosPassword"
+  host                    = "server2"
+  ker_dom_controller      = "EXAMPLE.COM"
+  kerberos_password       = true
+  port                    = 188
+  description             = "testacc ExternalAuthKerberosPassword"
   use_primary_auth_domain = true
   keytab                  = split(".", data.wallix-bastion_version.v.wab_version)[0] == "8" ? "" : filebase64("/tmp/testacc_data")
 }


### PR DESCRIPTION
BUG FIXES:

* **resource/wallix-bastion_externalauth_kerberos**: deprecate `login_attribute` argument (it produces Bad Request with API v3.12)